### PR TITLE
Scripts for comparing 2d density kernel performance

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,8 @@ add_executable(${PROJECT_NAME}
     src/charge_density_global_2d.cuh
     src/charge_density_shared_2d.cu
     src/charge_density_shared_2d.cuh
+    src/timer.cu
+    src/timer.cuh
 )
 
 target_include_directories(${PROJECT_NAME}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,8 @@ target_compile_options(${PROJECT_NAME}
     PRIVATE --expt-relaxed-constexpr
 )
 
-##[[
+# Comment/uncomment this line to disable/enable all compile definitions.
+#[[
 target_compile_definitions(${PROJECT_NAME}
     PRIVATE DEBUG
 )

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+cmake -S . -B build
+cd build
+make
+if [ $? -ne 0 ]; then
+    exit 1
+fi

--- a/build_and_run.sh
+++ b/build_and_run.sh
@@ -1,19 +1,19 @@
 #!/bin/bash
 
-cmake -S . -B build
-cd build
-make
+./build.sh
 if [ $? -ne 0 ]; then
-    return 1
+    exit 1
 fi
+
+cd build
 ./master_thesis $1 $2 $3 $4 $5 0 ../output $6 $7 $8
 if [ $? -ne 0 ]; then
     cd ..
-    return 1
+    exit 1
 fi
 ./master_thesis $1 $2 $3 $4 $5 1 ../output $6 $7 $8
 if [ $? -ne 0 ]; then
     cd ..
-    return 1
+    exit 1
 fi
 cd ..

--- a/build_and_run.sh
+++ b/build_and_run.sh
@@ -6,15 +6,14 @@ make
 if [ $? -ne 0 ]; then
     return 1
 fi
-./master_thesis $1 $2 $3 $4 $5 0 ../output $6 $7
+./master_thesis $1 $2 $3 $4 $5 0 ../output $6 $7 $8
 if [ $? -ne 0 ]; then
     cd ..
     return 1
 fi
-./master_thesis $1 $2 $3 $4 $5 1 ../output $6 $7
+./master_thesis $1 $2 $3 $4 $5 1 ../output $6 $7 $8
 if [ $? -ne 0 ]; then
     cd ..
     return 1
 fi
 cd ..
-python scripts/compare_densities.py $1 $2

--- a/build_and_time_both.sh
+++ b/build_and_time_both.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+
+run () {
+    local dim_x=$1
+    local dim_y=$1
+    local dim_z=1
+    local cell_size=64
+    local particles_per_cell=16
+    local version=$2
+    local output="../output"
+    local distribution=$3
+    local should_save=0
+    ./master_thesis ${dim_x} ${dim_y} ${dim_z} ${cell_size} \
+        ${particles_per_cell} ${version} ${output} ${distribution} \
+        ${should_save}
+}
+
+get_duration () {
+    local dim=$1
+    local version=$2
+    local distribution=$3
+    local time_keyword="took"
+    run ${dim} ${version} ${distribution} | grep -i ${time_keyword} | tr -cd 0-9
+}
+
+echo_with_comma () {
+    local IFS=","
+    echo "$*"
+}
+
+distribution=${1:-0}
+dimensions=(16 32 64 128 256 512 1024 2048)
+
+./build.sh
+if [ $? -ne 0 ]; then
+    exit 1
+fi
+
+cd build
+
+
+echo -n "Selected particle distribution: "
+case ${distribution} in
+    0)
+        echo uniform
+        ;;
+    1)
+        echo 2D pattern
+        ;;
+esac
+
+duration_global=()
+duration_shared=()
+for dim in "${dimensions[@]}"; do
+    echo "${dim}x${dim}"
+    echo -n "  global "
+    duration_global+=($(get_duration ${dim} ${distribution} 0))
+    echo "done"
+    echo -n "  shared "
+    duration_shared+=($(get_duration ${dim} ${distribution} 1))
+    echo "done"
+done
+
+cd ..
+filepath=output/durations_both.csv
+> ${filepath}
+echo_with_comma ${dimensions[@]} >> ${filepath}
+echo_with_comma ${duration_global[@]} >> ${filepath}
+echo_with_comma ${duration_shared[@]} >> ${filepath}
+
+exit 0

--- a/build_and_time_repeated.sh
+++ b/build_and_time_repeated.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+
+run () {
+    local dim_x=$1
+    local dim_y=$2
+    local dim_z=1
+    local cell_size=64
+    local particles_per_cell=16
+    local version=$3
+    local output="../output"
+    local distribution=$4
+    local should_save=0
+    ./master_thesis ${dim_x} ${dim_y} ${dim_z} ${cell_size} \
+        ${particles_per_cell} ${version} ${output} ${distribution} \
+        ${should_save}
+}
+
+get_duration () {
+    local dim_x=$1
+    local dim_y=$2
+    local version=$3
+    local distribution=$4
+    local time_keyword="took"
+    run ${dim_x} ${dim_y} ${version} ${distribution} | grep -i ${time_keyword} | tr -cd 0-9
+}
+
+echo_with_comma () {
+    local IFS=","
+    echo "$*"
+}
+
+dim_x=$1
+dim_y=$2
+version=$3
+distribution=$4
+run_count=$5
+
+./build.sh
+if [ $? -ne 0 ]; then
+    exit 1
+fi
+
+cd build
+
+
+echo -n "Selected particle distribution: "
+case ${distribution} in
+    0)
+        echo uniform
+        ;;
+    1)
+        echo 2D pattern
+        ;;
+esac
+
+durations=()
+echo "Dimensions: ${dim_x}x${dim_y}"
+for i in $(seq 1 ${run_count}); do
+    echo -n "Iteration ${i} "
+    durations+=($(get_duration ${dim_x} ${dim_y} ${version} ${distribution}))
+    echo "done"
+done
+
+cd ..
+filepath=output/durations_repeated.csv
+> ${filepath}
+echo_with_comma ${durations[@]} >> ${filepath}
+
+exit 0

--- a/scripts/compare_densities.py
+++ b/scripts/compare_densities.py
@@ -40,6 +40,9 @@ def main():
 
     print(f'Max absolute error: {absolute_errors.max()}')
     print(f'Number of cells with errors larger than the tolerance: {has_error.sum()}')
+    if (has_error.size > ((64+2) * (64+2))):
+        print('Grid too large. Exiting without plotting.')
+        return
 
     # Initialize size of figure before drawing rectangles since add_patch
     # doesn't resize the axes.

--- a/scripts/plot_durations_both.py
+++ b/scripts/plot_durations_both.py
@@ -1,0 +1,33 @@
+import csv
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+
+def main():
+    scripts_directory = Path(__file__).parent
+    root_directory = scripts_directory.parent
+    output_directory = root_directory / 'output'
+
+    with open(output_directory / 'durations_both.csv') as file:
+        reader = csv.reader(file, quoting=csv.QUOTE_NONNUMERIC)
+        rows = [row[:-1] for row in reader]
+    dimensions = rows[0]
+    durations_global = np.array(rows[1])
+    durations_shared = np.array(rows[2])
+
+    difference = durations_global - durations_shared
+    performance_gain = np.divide(difference, durations_global)
+
+    plt.plot(np.log2(dimensions), performance_gain*100, '*-')
+    plt.legend('global', 'shared')
+    plt.xticks(np.log2(dimensions))
+    plt.xlabel('log2(grid dimension) (square grid)')
+    plt.ylabel('Performance gain (%)')
+    plt.grid(True)
+    plt.show()
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/plot_durations_repeated.py
+++ b/scripts/plot_durations_repeated.py
@@ -1,0 +1,27 @@
+import csv
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+
+def main():
+    scripts_directory = Path(__file__).parent
+    root_directory = scripts_directory.parent
+    output_directory = root_directory / 'output'
+
+    with open(output_directory / 'durations_repeated.csv') as file:
+        reader = csv.reader(file, quoting=csv.QUOTE_NONNUMERIC)
+        rows = [row[:-1] for row in reader]
+    durations_shared = rows[0]
+
+    plt.plot(durations_shared, '*-')
+    plt.legend('global', 'shared')
+    plt.xlabel('i')
+    plt.ylabel('Duration (µs)')
+    plt.grid(True)
+    plt.show()
+
+
+if __name__ == '__main__':
+    main()

--- a/src/charge_density_shared_2d.cu
+++ b/src/charge_density_shared_2d.cu
@@ -224,6 +224,10 @@ thesis::ChargeDensityShared2d::ChargeDensityShared2d(
     particle_count_per_cell{ particle_count },
     block_count{ block_count }
 {
+    // Particle indices [0, 1, 2, ...] only need to be initialized once.
+    initialize_particle_indices<<<block_count, block_size>>>(
+        particle_count, particle_indices_before.i
+    );
     // Run the sorting with uninitialized temporary storage to compute the
     // required temporary storage size.
     sort_particles_by_cell(particle_count);
@@ -251,9 +255,6 @@ void thesis::ChargeDensityShared2d::compute(
     const float particle_charge, const int3 grid_dimensions,
     const int cell_size, float *densities
 ) {
-    initialize_particle_indices<<<block_count, block_size>>>(
-        particle_count, particle_indices_before.i
-    );
     initialize_particle_cell_indices<<<block_count, block_size>>>(
         pos_x, pos_y, particle_count, grid_dimensions, cell_size,
         particle_cell_indices_before.i

--- a/src/timer.cu
+++ b/src/timer.cu
@@ -1,0 +1,24 @@
+#include "timer.cuh"
+
+#include <iostream>
+
+using namespace std::chrono;
+
+thesis::Timer::Timer(std::string name)
+    : name{ name }, start{ high_resolution_clock::now() } {
+}
+
+thesis::Timer::~Timer() {
+    using namespace std::chrono_literals;
+
+    const auto end = high_resolution_clock::now();
+    const auto duration = end - start;
+    std::cout << name << " took ";
+    if (duration > 0ms) {
+        const auto duration_ms = duration_cast<milliseconds>(duration);
+        std::cout << duration_ms.count() << " ms.\n";
+    } else {
+        const auto duration_us = duration_cast<microseconds>(duration);
+        std::cout << duration_us.count() << " µs.\n";
+    }
+}

--- a/src/timer.cu
+++ b/src/timer.cu
@@ -13,12 +13,6 @@ thesis::Timer::~Timer() {
 
     const auto end = high_resolution_clock::now();
     const auto duration = end - start;
-    std::cout << name << " took ";
-    if (duration > 0ms) {
-        const auto duration_ms = duration_cast<milliseconds>(duration);
-        std::cout << duration_ms.count() << " ms.\n";
-    } else {
-        const auto duration_us = duration_cast<microseconds>(duration);
-        std::cout << duration_us.count() << " µs.\n";
-    }
+    const auto duration_us = duration_cast<microseconds>(duration);
+    std::cout << name << " took " << duration_us.count() << " µs.\n";
 }

--- a/src/timer.cuh
+++ b/src/timer.cuh
@@ -1,0 +1,18 @@
+#ifndef THESIS_TIMER_CUH
+#define THESIS_TIMER_CUH
+
+#include <chrono>
+#include <string>
+
+namespace thesis {
+    class Timer {
+    public:
+        Timer(std::string name);
+        ~Timer();
+    private:
+        std::string name;
+        std::chrono::high_resolution_clock::time_point start;
+    };
+};
+
+#endif


### PR DESCRIPTION
# Changes
We can now compare how long it takes to compute the charge density using the two methods and compare them. We can also repeatedly run one version and plot how the duration varies between runs, as in figure 1. This closes #10.

# Plots
![timeComparison_4096x1024_16particlesPerCell](https://github.com/user-attachments/assets/c8b28213-fb78-4621-b458-64925deefe5c)
Figure 1. Time comparison between global and shared version for 4096x1024 grid with 16 particles per cell, specifically how much faster the shared is. We can see no clear trend here.
