### PR TITLE
Remove charge density class

### DIFF
--- a/src/charge_density_global_2d.cu
+++ b/src/charge_density_global_2d.cu
@@ -3,7 +3,7 @@
 #include "common.cuh"
 
 __global__
-void thesis::charge_density_global_2d(
+void thesis::global_2d::charge_density(
     const float *pos_x, const float *pos_y, const size_t particle_count,
     const float particle_charge, const int3 grid_dimensions,
     const int cell_size, float *densities

--- a/src/charge_density_global_2d.cuh
+++ b/src/charge_density_global_2d.cuh
@@ -1,10 +1,10 @@
 #ifndef THESIS_CHARGE_DENSITY_GLOBAL_2D_CUH
 #define THESIS_CHARGE_DENSITY_GLOBAL_2D_CUH
 
-namespace thesis {
+namespace thesis::global_2d {
     __global__
     /// Computes 2D charge density using only global memory.
-    void charge_density_global_2d(
+    void charge_density(
         const float *pos_x, const float *pos_y, size_t particle_count,
         float particle_charge, int3 grid_dimensions, int cell_size,
         float *densities

--- a/src/charge_density_shared_2d.cu
+++ b/src/charge_density_shared_2d.cu
@@ -19,254 +19,211 @@ namespace {
         v += v == 0;
         return static_cast<int>(v);
     }
-
-    __global__
-    void charge_density_shared_2d(
-        const float *pos_x, const float *pos_y, const size_t particle_count,
-        const float particle_charge, const int3 grid_dimensions,
-        const int cell_size, int *particle_indices,
-        const int *particle_cell_indices, const int *particle_indices_rel_cell,
-        const int *particle_count_per_cell, float *densities
-    ) {
-        // Grid-stride loop. Equivalent to regular if-statement grid is large enough
-        // to cover all iterations of the loop.
-        for (
-            auto index = blockIdx.x * blockDim.x + threadIdx.x;
-            index < particle_count;
-            index += blockDim.x * gridDim.x
-        ) {
-            // Each particle will contribute to its 4 surrounding cells.
-            __shared__ float s_densities[4][block_size];
-
-            // 1D index of first enclosing cell, i.e., with lowest index.
-            const auto first_cell_index = particle_cell_indices[index];
-            const auto particle_index = particle_indices[index];
-            const auto particle_index_rel_cell = particle_indices_rel_cell[index];
-            const auto cell_particle_count = particle_count_per_cell[index];
-
-            // Convert 1D index to 2D.
-            const auto i = first_cell_index % grid_dimensions.x;
-            const auto j = first_cell_index / grid_dimensions.x;
-
-            // Centers of all surrounding cells, named relative the indices (i,j,k)
-            // of the surrounding cell closest to the origin (cell_000).
-            const auto cell_000_center = int3{ i,     j    , 0 };
-            const auto cell_100_center = int3{ i + 1, j    , 0 };
-            const auto cell_010_center = int3{ i,     j + 1, 0 };
-            const auto cell_110_center = int3{ i + 1, j + 1, 0 };
-
-            const auto position = float3{
-                pos_x[particle_index], pos_y[particle_index], 0
-            };
-            const auto [ u, v, w ] = cell_coordinates(position, cell_size);
-            // uvw-position relative to cell_000.
-            const auto pos_rel_cell = float3{
-                u - cell_000_center.x,
-                v - cell_000_center.y,
-                w - cell_000_center.z
-            };
-            // Cell weights based on the distance to the particle.
-            const auto cell_000_weight = (1 - pos_rel_cell.x) * (1 - pos_rel_cell.y);
-            const auto cell_100_weight =      pos_rel_cell.x  * (1 - pos_rel_cell.y);
-            const auto cell_010_weight = (1 - pos_rel_cell.x) *      pos_rel_cell.y;
-            const auto cell_110_weight =      pos_rel_cell.x  *      pos_rel_cell.y;
-
-            // Linear cell indices.
-            const auto cell_000_index = cell_index(cell_000_center, grid_dimensions);
-            const auto cell_100_index = cell_index(cell_100_center, grid_dimensions);
-            const auto cell_010_index = cell_index(cell_010_center, grid_dimensions);
-            const auto cell_110_index = cell_index(cell_110_center, grid_dimensions);
-
-            // Weighted sum of the particle's charge.
-            s_densities[0][threadIdx.x] = particle_charge * cell_000_weight;
-            s_densities[1][threadIdx.x] = particle_charge * cell_100_weight;
-            s_densities[2][threadIdx.x] = particle_charge * cell_010_weight;
-            s_densities[3][threadIdx.x] = particle_charge * cell_110_weight;
-            // Wait until the shared memory is filled.
-            __syncthreads();
-
-            // In-place reduction in shared memory.
-            for (
-                auto stride = ceil_pow2(cell_particle_count) / 2;
-                stride > 0;
-                stride /= 2
-            ) {
-                // Shorthand notation.
-                const auto i = particle_index_rel_cell;
-                // Make sure not to stride outside of the cell range. Crucial when
-                // the number of particles in a cell isn't a power of two.
-                if (i < stride && i + stride < cell_particle_count) {
-                    s_densities[0][threadIdx.x] += s_densities[0][threadIdx.x + stride];
-                    s_densities[1][threadIdx.x] += s_densities[1][threadIdx.x + stride];
-                    s_densities[2][threadIdx.x] += s_densities[2][threadIdx.x + stride];
-                    s_densities[3][threadIdx.x] += s_densities[3][threadIdx.x + stride];
-                }
-                __syncthreads();
-            }
-
-            // Store reduction to global memory.
-            if (particle_index_rel_cell == 0) {
-                atomicAdd(&densities[cell_000_index], s_densities[0][threadIdx.x]);
-                atomicAdd(&densities[cell_100_index], s_densities[1][threadIdx.x]);
-                atomicAdd(&densities[cell_010_index], s_densities[2][threadIdx.x]);
-                atomicAdd(&densities[cell_110_index], s_densities[3][threadIdx.x]);
-            }
-        }
-    }
-
-    __global__
-    void initialize_particle_indices(
-        const size_t particle_count, int *indices
-    ) {
-        // Grid-stride loop. Equivalent to regular if-statement grid is large enough
-        // to cover all iterations of the loop.
-        for (
-            auto index = blockIdx.x * blockDim.x + threadIdx.x;
-            index < particle_count;
-            index += blockDim.x * gridDim.x
-        ) {
-            indices[index] = index;
-        }
-    }
-
-    __global__
-    void initialize_particle_cell_indices(
-        const float *pos_x, const float *pos_y, const size_t particle_count,
-        const int3 grid_dimensions, const int cell_size, int *cell_indices
-    ) {
-        // Grid-stride loop. Equivalent to regular if-statement grid is large enough
-        // to cover all iterations of the loop.
-        for (
-            auto particle_index = blockIdx.x * blockDim.x + threadIdx.x;
-            particle_index < particle_count;
-            particle_index += blockDim.x * gridDim.x
-        ) {
-            // Position in world coordinates.
-            const auto position = float3{
-                pos_x[particle_index], pos_y[particle_index], 0
-            };
-            // Position in grid coordinates.
-            const auto [ u, v, w ] = cell_coordinates(position, cell_size);
-            // 2D indices of first enclosing cell, by first meaning the one with
-            // lowest index, i.e., closest to the origin.
-            const auto i = static_cast<int>(floor(u));
-            const auto j = static_cast<int>(floor(v));
-
-            cell_indices[particle_index] = i + j * grid_dimensions.x;
-        }
-    }
-
-    __global__
-    void initialize_particle_occupancy(
-        const size_t particle_count, const int *cell_indices,
-        int *particle_indices_rel_cell, int *particle_count_per_cell
-    ) {
-        // Grid-stride loop. Equivalent to regular if-statement grid is large enough
-        // to cover all iterations of the loop.
-        for (
-            auto index = blockIdx.x * blockDim.x + threadIdx.x;
-            index < particle_count;
-            index += blockDim.x * gridDim.x
-        ) {
-            __shared__ int s_cell_indices[block_size];
-            __shared__ int s_particle_indices_rel_cell[block_size];
-            // Incrementing 0, 1, 2, ..., for each new cell.
-            __shared__ uint s_cell_ids[block_size];
-            // Indexed with cell id, not cell index.
-            __shared__ uint s_particle_count_per_cell_id[block_size];
-
-            s_cell_indices[threadIdx.x] = cell_indices[index];
-            __syncthreads();
-
-            // TODO: Parallelize.
-            if (threadIdx.x == 0) {
-                s_particle_indices_rel_cell[0] = 0;
-                s_cell_ids[0] = 0;
-                // Start on 1 since we already set the value for i = 0.
-                auto particle_index_rel_cell = 1;
-                auto cell_id = 0;
-                auto cell_particle_count = 0;
-                auto previous_cell_index = s_cell_indices[0];
-                // Don't iterate too far in the last block.
-                const auto block_particle_count = min(
-                    particle_count - index, static_cast<size_t>(block_size)
-                );
-                for (auto i = 1uz; i < block_particle_count; ++i) {
-                    const auto cell_index = s_cell_indices[i];
-                    ++cell_particle_count;
-                    if (cell_index > previous_cell_index) {
-                        s_particle_count_per_cell_id[cell_id] = cell_particle_count;
-                        particle_index_rel_cell = 0;
-                        ++cell_id;
-                        cell_particle_count = 0;
-                        previous_cell_index = cell_index;
-                    }
-                    s_particle_indices_rel_cell[i] = particle_index_rel_cell++;
-                    s_cell_ids[i] = cell_id;
-                }
-                s_particle_count_per_cell_id[cell_id] = cell_particle_count + 1;
-            }
-            __syncthreads();
-            particle_indices_rel_cell[index] = s_particle_indices_rel_cell[threadIdx.x];
-            const auto cell_index = s_cell_ids[threadIdx.x];
-            particle_count_per_cell[index] = s_particle_count_per_cell_id[cell_index];
-        }
-    }
 };
 
-thesis::ChargeDensityShared2d::ChargeDensityShared2d(
-    const size_t particle_count, const size_t block_count
-) : particle_indices_before{ particle_count },
-    particle_indices_after{ particle_count },
-    particle_cell_indices_before{ particle_count },
-    particle_cell_indices_after{ particle_count },
-    particle_indices_rel_cell{ particle_count },
-    particle_count_per_cell{ particle_count },
-    block_count{ block_count }
-{
-    // Particle indices [0, 1, 2, ...] only need to be initialized once.
-    initialize_particle_indices<<<block_count, block_size>>>(
-        particle_count, particle_indices_before.i
-    );
-    // Run the sorting with uninitialized temporary storage to compute the
-    // required temporary storage size.
-    sort_particles_by_cell(particle_count);
-    // Allocate temporary storage.
-    cudaMalloc(&sort_storage, sort_storage_size);
+__global__
+void thesis::shared_2d::initialize_particle_indices(
+    const size_t particle_count, int *indices
+) {
+    // Grid-stride loop. Equivalent to regular if-statement grid is large enough
+    // to cover all iterations of the loop.
+    for (
+        auto index = blockIdx.x * blockDim.x + threadIdx.x;
+        index < particle_count;
+        index += blockDim.x * gridDim.x
+    ) {
+        indices[index] = index;
+    }
 }
 
-thesis::ChargeDensityShared2d::~ChargeDensityShared2d() {
-    cudaFree(sort_storage);
+__global__
+void thesis::shared_2d::initialize_particle_cell_indices(
+    const float *pos_x, const float *pos_y, const size_t particle_count,
+    const int3 grid_dimensions, const int cell_size, int *cell_indices
+) {
+    // Grid-stride loop. Equivalent to regular if-statement grid is large enough
+    // to cover all iterations of the loop.
+    for (
+        auto particle_index = blockIdx.x * blockDim.x + threadIdx.x;
+        particle_index < particle_count;
+        particle_index += blockDim.x * gridDim.x
+    ) {
+        // Position in world coordinates.
+        const auto position = float3{
+            pos_x[particle_index], pos_y[particle_index], 0
+        };
+        // Position in grid coordinates.
+        const auto [ u, v, w ] = cell_coordinates(position, cell_size);
+        // 2D indices of first enclosing cell, by first meaning the one with
+        // lowest index, i.e., closest to the origin.
+        const auto i = static_cast<int>(floor(u));
+        const auto j = static_cast<int>(floor(v));
+
+        cell_indices[particle_index] = i + j * grid_dimensions.x;
+    }
 }
 
-void thesis::ChargeDensityShared2d::sort_particles_by_cell(
+void thesis::shared_2d::sort_particles_by_cell(
+    void *sort_storage, size_t &sort_storage_size,
+    int *particle_cell_indices_before, int *particle_cell_indices_after,
+    int *particle_indices_before, int *particle_indices_after,
     const size_t particle_count
 ) {
     cub::DeviceRadixSort::SortPairs(
         sort_storage, sort_storage_size,
-        particle_cell_indices_before.i, particle_cell_indices_after.i,
-        particle_indices_before.i, particle_indices_after.i,
+        particle_cell_indices_before, particle_cell_indices_after,
+        particle_indices_before, particle_indices_after,
         particle_count
     );
 }
 
-void thesis::ChargeDensityShared2d::compute(
+__global__
+void thesis::shared_2d::initialize_particle_occupancy(
+    const size_t particle_count, const int *cell_indices,
+    int *particle_indices_rel_cell, int *particle_count_per_cell
+) {
+    // Grid-stride loop. Equivalent to regular if-statement grid is large enough
+    // to cover all iterations of the loop.
+    for (
+        auto index = blockIdx.x * blockDim.x + threadIdx.x;
+        index < particle_count;
+        index += blockDim.x * gridDim.x
+    ) {
+        __shared__ int s_cell_indices[block_size];
+        __shared__ int s_particle_indices_rel_cell[block_size];
+        // Incrementing 0, 1, 2, ..., for each new cell.
+        __shared__ uint s_cell_ids[block_size];
+        // Indexed with cell id, not cell index.
+        __shared__ uint s_particle_count_per_cell_id[block_size];
+
+        s_cell_indices[threadIdx.x] = cell_indices[index];
+        __syncthreads();
+
+        // TODO: Parallelize.
+        if (threadIdx.x == 0) {
+            s_particle_indices_rel_cell[0] = 0;
+            s_cell_ids[0] = 0;
+            // Start on 1 since we already set the value for i = 0.
+            auto particle_index_rel_cell = 1;
+            auto cell_id = 0;
+            auto cell_particle_count = 0;
+            auto previous_cell_index = s_cell_indices[0];
+            // Don't iterate too far in the last block.
+            const auto block_particle_count = min(
+                particle_count - index, static_cast<size_t>(block_size)
+            );
+            for (auto i = 1uz; i < block_particle_count; ++i) {
+                const auto cell_index = s_cell_indices[i];
+                ++cell_particle_count;
+                if (cell_index > previous_cell_index) {
+                    s_particle_count_per_cell_id[cell_id] = cell_particle_count;
+                    particle_index_rel_cell = 0;
+                    ++cell_id;
+                    cell_particle_count = 0;
+                    previous_cell_index = cell_index;
+                }
+                s_particle_indices_rel_cell[i] = particle_index_rel_cell++;
+                s_cell_ids[i] = cell_id;
+            }
+            s_particle_count_per_cell_id[cell_id] = cell_particle_count + 1;
+        }
+        __syncthreads();
+        particle_indices_rel_cell[index] = s_particle_indices_rel_cell[threadIdx.x];
+        const auto cell_index = s_cell_ids[threadIdx.x];
+        particle_count_per_cell[index] = s_particle_count_per_cell_id[cell_index];
+    }
+}
+
+__global__
+void thesis::shared_2d::charge_density(
     const float *pos_x, const float *pos_y, const size_t particle_count,
     const float particle_charge, const int3 grid_dimensions,
-    const int cell_size, float *densities
+    const int cell_size, const int *particle_indices,
+    const int *particle_cell_indices, const int *particle_indices_rel_cell,
+    const int *particle_count_per_cell, float *densities
 ) {
-    initialize_particle_cell_indices<<<block_count, block_size>>>(
-        pos_x, pos_y, particle_count, grid_dimensions, cell_size,
-        particle_cell_indices_before.i
-    );
-    sort_particles_by_cell(particle_count);
-    initialize_particle_occupancy<<<block_count, block_size>>>(
-        particle_count, particle_cell_indices_after.i,
-        particle_indices_rel_cell.i, particle_count_per_cell.i
-    );
-    charge_density_shared_2d<<<block_count, block_size>>>(
-        pos_x, pos_y, particle_count, particle_charge, grid_dimensions,
-        cell_size, particle_indices_after.i, particle_cell_indices_after.i,
-        particle_indices_rel_cell.i, particle_count_per_cell.i, densities
-    );
+    // Grid-stride loop. Equivalent to regular if-statement grid is large enough
+    // to cover all iterations of the loop.
+    for (
+        auto index = blockIdx.x * blockDim.x + threadIdx.x;
+        index < particle_count;
+        index += blockDim.x * gridDim.x
+    ) {
+        // Each particle will contribute to its 4 surrounding cells.
+        __shared__ float s_densities[4][block_size];
+
+        // 1D index of first enclosing cell, i.e., with lowest index.
+        const auto first_cell_index = particle_cell_indices[index];
+        const auto particle_index = particle_indices[index];
+        const auto particle_index_rel_cell = particle_indices_rel_cell[index];
+        const auto cell_particle_count = particle_count_per_cell[index];
+
+        // Convert 1D index to 2D.
+        const auto i = first_cell_index % grid_dimensions.x;
+        const auto j = first_cell_index / grid_dimensions.x;
+
+        // Centers of all surrounding cells, named relative the indices (i,j,k)
+        // of the surrounding cell closest to the origin (cell_000).
+        const auto cell_000_center = int3{ i,     j    , 0 };
+        const auto cell_100_center = int3{ i + 1, j    , 0 };
+        const auto cell_010_center = int3{ i,     j + 1, 0 };
+        const auto cell_110_center = int3{ i + 1, j + 1, 0 };
+
+        const auto position = float3{
+            pos_x[particle_index], pos_y[particle_index], 0
+        };
+        const auto [ u, v, w ] = cell_coordinates(position, cell_size);
+        // uvw-position relative to cell_000.
+        const auto pos_rel_cell = float3{
+            u - cell_000_center.x,
+            v - cell_000_center.y,
+            w - cell_000_center.z
+        };
+        // Cell weights based on the distance to the particle.
+        const auto cell_000_weight = (1 - pos_rel_cell.x) * (1 - pos_rel_cell.y);
+        const auto cell_100_weight =      pos_rel_cell.x  * (1 - pos_rel_cell.y);
+        const auto cell_010_weight = (1 - pos_rel_cell.x) *      pos_rel_cell.y;
+        const auto cell_110_weight =      pos_rel_cell.x  *      pos_rel_cell.y;
+
+        // Linear cell indices.
+        const auto cell_000_index = cell_index(cell_000_center, grid_dimensions);
+        const auto cell_100_index = cell_index(cell_100_center, grid_dimensions);
+        const auto cell_010_index = cell_index(cell_010_center, grid_dimensions);
+        const auto cell_110_index = cell_index(cell_110_center, grid_dimensions);
+
+        // Weighted sum of the particle's charge.
+        s_densities[0][threadIdx.x] = particle_charge * cell_000_weight;
+        s_densities[1][threadIdx.x] = particle_charge * cell_100_weight;
+        s_densities[2][threadIdx.x] = particle_charge * cell_010_weight;
+        s_densities[3][threadIdx.x] = particle_charge * cell_110_weight;
+        // Wait until the shared memory is filled.
+        __syncthreads();
+
+        // In-place reduction in shared memory.
+        for (
+            auto stride = ceil_pow2(cell_particle_count) / 2;
+            stride > 0;
+            stride /= 2
+        ) {
+            // Shorthand notation.
+            const auto i = particle_index_rel_cell;
+            // Make sure not to stride outside of the cell range. Crucial when
+            // the number of particles in a cell isn't a power of two.
+            if (i < stride && i + stride < cell_particle_count) {
+                s_densities[0][threadIdx.x] += s_densities[0][threadIdx.x + stride];
+                s_densities[1][threadIdx.x] += s_densities[1][threadIdx.x + stride];
+                s_densities[2][threadIdx.x] += s_densities[2][threadIdx.x + stride];
+                s_densities[3][threadIdx.x] += s_densities[3][threadIdx.x + stride];
+            }
+            __syncthreads();
+        }
+
+        // Store reduction to global memory.
+        if (particle_index_rel_cell == 0) {
+            atomicAdd(&densities[cell_000_index], s_densities[0][threadIdx.x]);
+            atomicAdd(&densities[cell_100_index], s_densities[1][threadIdx.x]);
+            atomicAdd(&densities[cell_010_index], s_densities[2][threadIdx.x]);
+            atomicAdd(&densities[cell_110_index], s_densities[3][threadIdx.x]);
+        }
+    }
 }

--- a/src/int_array.cu
+++ b/src/int_array.cu
@@ -20,13 +20,10 @@ void thesis::HostIntArray::save(std::filesystem::path filepath) {
     file << '\n';
 }
 
-thesis::DeviceIntArray::DeviceIntArray(const size_t count) {
-    const auto size = count * type_size;
+thesis::DeviceIntArray::DeviceIntArray(const HostIntArray &indices) {
+    const auto size = indices.i.size() * type_size;
     cudaMalloc(&i, size);
 }
-
-thesis::DeviceIntArray::DeviceIntArray(const HostIntArray &indices)
-    : DeviceIntArray{ indices.i.size() } {}
 
 thesis::DeviceIntArray::~DeviceIntArray() {
     cudaFree(i);

--- a/src/int_array.cuh
+++ b/src/int_array.cuh
@@ -20,7 +20,6 @@ namespace thesis {
     struct DeviceIntArray {
         int *i;
 
-        explicit DeviceIntArray(size_t count);
         DeviceIntArray(const HostIntArray &indices);
         DeviceIntArray(const DeviceIntArray &) = delete;
         ~DeviceIntArray();

--- a/src/main.cu
+++ b/src/main.cu
@@ -85,9 +85,37 @@ int main(int argc, char *argv[]) {
     auto d_charge_densities = DeviceGrid{ grid_dimensions };
 
     // Prepare shared version, even if it is not used.
-    auto charge_density_shared_2d = ChargeDensityShared2d(
-        particle_count, block_count
+    auto h_particle_indices_before = HostIntArray{ particle_count };
+    auto h_particle_indices_after = HostIntArray{ particle_count };
+    auto h_particle_cell_indices_before = HostIntArray{ particle_count };
+    auto h_particle_cell_indices_after = HostIntArray{ particle_count };
+    auto h_particle_indices_rel_cell = HostIntArray{ particle_count };
+    auto h_particle_count_per_cell = HostIntArray{ particle_count };
+    
+    auto d_particle_indices_before = DeviceIntArray{ h_particle_indices_before };
+    auto d_particle_indices_after = DeviceIntArray{ h_particle_indices_after };
+    auto d_particle_cell_indices_before = DeviceIntArray{ h_particle_cell_indices_before };
+    auto d_particle_cell_indices_after = DeviceIntArray{ h_particle_cell_indices_after };
+    auto d_particle_indices_rel_cell = DeviceIntArray{ h_particle_indices_rel_cell };
+    auto d_particle_count_per_cell = DeviceIntArray{ h_particle_count_per_cell };
+    
+    void *sort_storage = nullptr;
+    auto sort_storage_size = size_t{};
+    
+    // Particle indices [0, 1, 2, ...] only need to be initialized once.
+    shared_2d::initialize_particle_indices<<<block_count, block_size>>>(
+        particle_count, d_particle_indices_before.i
     );
+    // Run the sorting with uninitialized sort storage to compute the
+    // required temporary storage size.
+    shared_2d::sort_particles_by_cell(
+        sort_storage, sort_storage_size,
+        d_particle_cell_indices_before.i, d_particle_cell_indices_after.i,
+        d_particle_indices_before.i, d_particle_indices_after.i, particle_count
+    );
+    // Allocate sort storage.
+    cudaMalloc(&sort_storage, sort_storage_size);
+    
 
     // Limit the lifetime of the timer using a scope.
     {
@@ -95,15 +123,36 @@ int main(int argc, char *argv[]) {
         // Run kernel.
         switch (selected_version) {
         case Version::global:
-            charge_density_global_2d<<<block_count, block_size>>>(
-                d_particles.pos_x, d_particles.pos_y, particle_count, particle_charge,
-                grid_dimensions, cell_size, d_charge_densities.cells
+            using namespace global_2d;
+            charge_density<<<block_count, block_size>>>(
+                d_particles.pos_x, d_particles.pos_y, particle_count,
+                particle_charge, grid_dimensions, cell_size,
+                d_charge_densities.cells
             );
             break;
         case Version::shared: {
-            charge_density_shared_2d.compute(
-                d_particles.pos_x, d_particles.pos_y, particle_count, particle_charge,
-                grid_dimensions, cell_size, d_charge_densities.cells
+            using namespace shared_2d;
+            initialize_particle_cell_indices<<<block_count, block_size>>>(
+                d_particles.pos_x, d_particles.pos_y, particle_count,
+                grid_dimensions, cell_size, d_particle_cell_indices_before.i
+            );
+            sort_particles_by_cell(
+                sort_storage, sort_storage_size,
+                d_particle_cell_indices_before.i,
+                d_particle_cell_indices_after.i,
+                d_particle_indices_before.i,
+                d_particle_indices_after.i, particle_count
+            );
+            initialize_particle_occupancy<<<block_count, block_size>>>(
+                particle_count, d_particle_cell_indices_after.i,
+                d_particle_indices_rel_cell.i, d_particle_count_per_cell.i
+            );
+            charge_density<<<block_count, block_size>>>(
+                d_particles.pos_x, d_particles.pos_y, particle_count,
+                particle_charge, grid_dimensions, cell_size,
+                d_particle_indices_after.i, d_particle_cell_indices_after.i,
+                d_particle_indices_rel_cell.i, d_particle_count_per_cell.i,
+                d_charge_densities.cells
             );
             break;
         }
@@ -115,6 +164,9 @@ int main(int argc, char *argv[]) {
         // Wait for the kernel to finish.
         cudaDeviceSynchronize();
     }
+
+    // Deallocate the sort storage.
+    cudaFree(sort_storage);
 
     // Save data to disk.
     if (should_save) {


### PR DESCRIPTION
The class has been replaced with free functions in a namespace. Changed the global version to match as well. This closes #15.