### PR TITLE
Blocks associated with cells

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,7 @@ target_compile_features(${PROJECT_NAME} PUBLIC cxx_std_20)
 target_compile_options(${PROJECT_NAME}
     PRIVATE -arch=sm_75
     PRIVATE --expt-relaxed-constexpr
+    PRIVATE --Werror=all-warnings
 )
 
 target_link_libraries(${PROJECT_NAME}

--- a/src/charge_density_shared_2d.cuh
+++ b/src/charge_density_shared_2d.cuh
@@ -21,6 +21,14 @@ namespace thesis::shared_2d {
         const int *particle_indices_in, int *particle_indices_out,
         size_t particle_count
     );
+
+    __global__
+    void associate_blocks_with_cells(
+        size_t particle_count, size_t max_block_count,
+        const int *associated_cell_indices, int *cell_indices,
+        int *first_particle_indices, int *cell_particle_counts,
+        int *block_count
+    );
 };
 
 #endif


### PR DESCRIPTION
# Changes
The added kernel populates three arrays and returns the number of blocks needed to handle all associated cells. All of this can be used on the charge density kernel later. this closes #29.

# Validation
We use the same setup as in pr #27 with the below cell indices:
```
    cell indices sorted: [ 0  2  3  5  5  6  7  8 11 12 12 13]
```
Each entry in the generated arrays below correspond to a single block:
```
          cell indices: [ 0  2  3  5  6  7  8 11 12 13  0  0]
  cell particle counts: [ 1  1  1  2  1  1  1  1  2  1  0  0]
first particle indices: [ 0  1  2  3  5  6  7  8  9 11  0  0]
```
We can see for example that the fourth block will handle cell 5 containing 2 particle starting at index 3. The particle index is relative to the sorted particles, where index 0 refers to the first of the sorted particle. The output makes sense in this case and should work for all cases. Here ten blocks was needed out of a max of twelve blocks. The max number of blocks needed is computed based on the size of the grid where one row and column will never have associated particles. In this case where the grid with ghost cells is 5x4 the max number of blocks is $(5-1)(4-1)=12$.