### PR TITLE
Cell associations contextualized

### DIFF
--- a/src/charge_density_shared_2d.cuh
+++ b/src/charge_density_shared_2d.cuh
@@ -31,6 +31,12 @@ namespace thesis::shared_2d {
     );
 
     __global__
+    void contextualize_cell_associations(
+        size_t particle_count, const int *associated_cell_indices,
+        int *particle_indices_rel_cell, int *particle_count_per_cell
+    );
+
+    __global__
     /**
      * Computes 2D charge density using global and shared memory.
      * 


### PR DESCRIPTION
# Changes
For each particle two values are computed: the number of particles associated to the same cell, and the particles relative index within the cell. This closes #33.

# Validation
We use the same setup as in pr #27 with the same cell indices and show the two generated arrays along side it:
```
cell indices sorted: [ 0  2  3  5  5  6  7  8 11 12 12 13]
particles per cell:  [ 1  1  1  2  2  1  1  1  1  2  2  1]
index relative cell: [ 0  0  0  0  1  0  0  0  0  0  1  0]
```
We can see the output is correct for this small setup, where the relative index is incrementing when a cell is associated with multiple particles.